### PR TITLE
fix go:generate for oapi-codegen library

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1,4 +1,4 @@
-//go:generate oapi-codegen --package=api --generate types,chi-server,spec -o api.gen.go ../spec/openapi.yaml
+//go:generate go run github.com/deepmap/oapi-codegen/cmd/oapi-codegen --package=api --generate types,chi-server,spec -o api.gen.go ../spec/openapi.yaml
 //go:generate go run ../cmd/updImpl.go
 
 package api


### PR DESCRIPTION
This PR update the `//go:generate oapi-codegen` to `//go:generate go run github.com/deepmap/oapi-codegen/cmd/oapi-codegen`. So, manual installation of `oapi-codegen` is not needed in order to generate the OpenAPI spec.